### PR TITLE
fix issues with PgFmt when using lsp

### DIFF
--- a/plugin/psql.lua
+++ b/plugin/psql.lua
@@ -5,6 +5,13 @@ vim.api.nvim_create_user_command(
 	psql.psql_run_curr_buf,
 	{}
 )
+
+vim.api.nvim_create_user_command(
+	"PgRunCursor",
+	psql.psql_run_close_to_cursor,
+	{}
+)
+
 vim.api.nvim_create_user_command(
 	"PgCancel",
 	psql.psql_cancel,


### PR DESCRIPTION
I ran into issues using `PgFmt` in combination with my lsp. The change fixes this issue for me. I'm using `sqls` and `nanotee/sqls.nvim`. The lsp was not able to find the files again after the file was reloaded through `PgFmt`. This lead to a permanent issue that could only be resolved with closing and opening nvim.